### PR TITLE
[10.x] Adds transactions to seeder

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/WithDatabaseTransaction.php
+++ b/src/Illuminate/Database/Console/Seeds/WithDatabaseTransaction.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Database\Console\Seeds;
+
+trait WithDatabaseTransaction
+{
+    /**
+     * If database transaction should be used.
+     *
+     * @return bool
+     */
+    protected function useDatabaseTransaction()
+    {
+        return true;
+    }
+
+    /**
+     * Wraps the seeder call in a database transaction.
+     *
+     * @param  callable  $callback
+     * @return callable
+     */
+    public function withDatabaseTransaction(callable $callback)
+    {
+        if (isset($this->container)) {
+            return fn() => $this->container->make('db.connection')->transaction($callback);
+        }
+
+        return $callback;
+    }
+}

--- a/src/Illuminate/Database/Console/Seeds/WithDatabaseTransaction.php
+++ b/src/Illuminate/Database/Console/Seeds/WithDatabaseTransaction.php
@@ -23,7 +23,7 @@ trait WithDatabaseTransaction
     public function withDatabaseTransaction(callable $callback)
     {
         if (isset($this->container)) {
-            return fn() => $this->container->make('db.connection')->transaction($callback);
+            return fn () => $this->container->make('db.connection')->transaction($callback);
         }
 
         return $callback;

--- a/src/Illuminate/Database/Console/Seeds/stubs/seeder.stub
+++ b/src/Illuminate/Database/Console/Seeds/stubs/seeder.stub
@@ -3,6 +3,7 @@
 namespace {{ namespace }};
 
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Console\Seeds\WithDatabaseTransaction;
 use Illuminate\Database\Seeder;
 
 class {{ class }} extends Seeder

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database;
 use Illuminate\Console\Command;
 use Illuminate\Console\View\Components\TwoColumnDetail;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Database\Console\Seeds\WithDatabaseTransaction;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
@@ -188,6 +189,10 @@ abstract class Seeder
 
         if (isset($uses[WithoutModelEvents::class])) {
             $callback = $this->withoutModelEvents($callback);
+        }
+
+        if (isset($uses[WithDatabaseTransaction::class]) && $this->useDatabaseTransaction()) {
+            $callback = $this->withDatabaseTransaction($callback);
         }
 
         return $callback();

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -126,7 +126,7 @@ class SeedCommandTest extends TestCase
         $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
 
         $connection = m::mock(ConnectionInterface::class);
-        $connection->shouldReceive('transaction')->andReturn(fn($callback) => Assert::assertTrue($callback()));
+        $connection->shouldReceive('transaction')->andReturn(fn ($callback) => Assert::assertTrue($callback()));
 
         $container = m::mock(Container::class);
         $container->shouldReceive('call');


### PR DESCRIPTION
## What?

This PR enables the seeder to run inside a database transaction for added safety.

The `run()` command can be wrapped into a database transaction by adding the `WithDatabaseTransaction` trait into the seeder. In the same way that `WithoutModelEvents`, the `withDatabaseTransaction()` method wraps the call into a database transaction.

```php
use Illuminate\Database\Console\Seeds\WithDatabaseTransaction;

class PostSeeder
{
    use WithDatabaseTransaction;
    
    // ...
}
```

Since transactions can make the database seeding slower in some cases, especially on thousands or millions of rows, the developer can override the `useDatabaseTransaction()` to return a `true` or `false` if the call should be wrapped or not. This is much better than overriding `withDatabaseTransaction()`.

```php
use App\Models\Post;

public function useDatabaseTransaction()
{
    $connection = Post::query()->getConnection();

    // Only run transactions when SQLite uses a file database for better performance.
    return $connection->getDriverName() === 'sqlite'
        && $connection->getConfig('database') !== ':memory:';
}
```